### PR TITLE
Add .count and .avg to histogram metrics

### DIFF
--- a/src/main/java/org/datadog/jmeter/plugins/DatadogBackendClient.java
+++ b/src/main/java/org/datadog/jmeter/plugins/DatadogBackendClient.java
@@ -21,6 +21,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.backend.AbstractBackendListenerClient;
 import org.apache.jmeter.visualizers.backend.BackendListenerContext;
 import org.apache.jmeter.visualizers.backend.UserMetric;
+import org.datadog.jmeter.plugins.aggregation.ConcurrentAggregator;
 import org.datadog.jmeter.plugins.metrics.DatadogMetric;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/datadog/jmeter/plugins/aggregation/DatadogSketch.java
+++ b/src/main/java/org/datadog/jmeter/plugins/aggregation/DatadogSketch.java
@@ -1,0 +1,31 @@
+package org.datadog.jmeter.plugins.aggregation;
+
+import com.datadoghq.sketch.ddsketch.DDSketch;
+import com.datadoghq.sketch.ddsketch.mapping.IndexMapping;
+import com.datadoghq.sketch.ddsketch.store.Store;
+import java.util.function.Supplier;
+
+public class DatadogSketch extends DDSketch {
+
+    private long count = 0;
+    private double sum = 0;
+
+    public DatadogSketch(IndexMapping indexMapping, Supplier<Store> storeSupplier) {
+        super(indexMapping, storeSupplier);
+    }
+
+    @Override
+    public void accept(double value) {
+        this.count += 1;
+        this.sum += value;
+        super.accept(value);
+    }
+
+    public long getCountValue() {
+        return this.count;
+    }
+
+    public double getAverageValue() {
+        return this.sum / this.count;
+    }
+}

--- a/src/test/java/org/datadog/jmeter/plugins/aggregation/ConcurrentAggregatorTest.java
+++ b/src/test/java/org/datadog/jmeter/plugins/aggregation/ConcurrentAggregatorTest.java
@@ -3,7 +3,7 @@
  * Copyright 2021-present Datadog, Inc.
  */
 
-package org.datadog.jmeter.plugins;
+package org.datadog.jmeter.plugins.aggregation;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -89,13 +89,17 @@ public class ConcurrentAggregatorTest {
         service.awaitTermination(2, TimeUnit.SECONDS);
 
         List<DatadogMetric> metrics = aggregator.flushMetrics();
-        assertEquals(6, metrics.size());
+        assertEquals(7, metrics.size());
 
-        String[] suffixes = new String[] {".max", ".min", ".p99", ".p95", ".p90", ".p50"};
-        double[] values = new double[] {49, 1, 48, 47, 45, 24};
+        String[] suffixes = new String[] {".max", ".min", ".p99", ".p95", ".p90", ".avg", ".count"};
+        double[] values = new double[] {49, 1, 48, 47, 45, 25, N_THREADS};
         for(int i = 0; i < suffixes.length; i++) {
             assertEquals(metricName + suffixes[i], metrics.get(i).getName());
-            assertEquals("gauge", metrics.get(i).getType());
+            if(suffixes[i].equals(".count")){
+                assertEquals("count", metrics.get(i).getType());
+            } else {
+                assertEquals("gauge", metrics.get(i).getType());
+            }
             assertEquals(suffixes[i], values[i], (int)metrics.get(i).getValue(), 1e-10);
         }
     }

--- a/src/test/java/org/datadog/jmeter/plugins/aggregation/DatadogSketchTest.java
+++ b/src/test/java/org/datadog/jmeter/plugins/aggregation/DatadogSketchTest.java
@@ -1,0 +1,22 @@
+package org.datadog.jmeter.plugins.aggregation;
+
+import com.datadoghq.sketch.ddsketch.mapping.CubicallyInterpolatedMapping;
+import com.datadoghq.sketch.ddsketch.store.UnboundedSizeDenseStore;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class DatadogSketchTest {
+    private static final double RELATIVE_ACCURACY = 0.01;
+
+    @Test
+    public void testSketch(){
+        DatadogSketch sketch = new DatadogSketch(new CubicallyInterpolatedMapping(RELATIVE_ACCURACY), UnboundedSizeDenseStore::new);
+
+        for(int i = -10; i < 120; i++) {
+            sketch.accept(i);
+        }
+
+        assertEquals(130, sketch.getCountValue());
+        assertEquals(54.5, sketch.getAverageValue(), RELATIVE_ACCURACY);
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Histogram metrics currently only reports some percentiles + min and max. This PRs adds the `.count` (i.e how many elements in the sketch) and `.avg` (i.e the average value of the sketch).

### Description of the Change
This PRs extends the DDSketch implementation class to simply keep track of the elements added. Overall it just adds one `long` and one `double` per sketch.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [x] PR should not have `do-not-merge/` label attached.
- [x] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

