### PR TITLE
Fix includeSubResult parameter parsing

### DIFF
--- a/src/main/java/org/datadog/jmeter/plugins/DatadogBackendClient.java
+++ b/src/main/java/org/datadog/jmeter/plugins/DatadogBackendClient.java
@@ -181,6 +181,7 @@ public class DatadogBackendClient extends AbstractBackendListenerClient implemen
             throw new Exception("Invalid 'sendResultsAsLogs'. Value '" + sendResultsAsLogs + "' is not a boolean.");
         }
         this.sendResultsAsLogs = Boolean.parseBoolean(sendResultsAsLogs);
+        this.includeSubResults = context.getBooleanParameter(INCLUDE_SUB_RESULTS, DEFAULT_INCLUDE_SUB_RESULTS);
 
         scheduler = Executors.newScheduledThreadPool(1);
         this.timerHandle = scheduler.scheduleAtFixedRate(this, METRICS_SEND_INTERVAL, METRICS_SEND_INTERVAL, TimeUnit.SECONDS);


### PR DESCRIPTION
The includeSubResults was never parsed from the configuration.

Note: The BackendListener class still needs tests. Testing that the configuration is parsed correctly will be one of the goal.