### PR TITLE
Move configuration into its own class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,18 @@
       <version>3.5.11</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>2.0.7</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.7</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/datadog/jmeter/plugins/DatadogBackendClient.java
+++ b/src/main/java/org/datadog/jmeter/plugins/DatadogBackendClient.java
@@ -24,6 +24,8 @@ import org.apache.jmeter.visualizers.backend.AbstractBackendListenerClient;
 import org.apache.jmeter.visualizers.backend.BackendListenerContext;
 import org.apache.jmeter.visualizers.backend.UserMetric;
 import org.datadog.jmeter.plugins.aggregation.ConcurrentAggregator;
+import org.datadog.jmeter.plugins.exceptions.DatadogApiException;
+import org.datadog.jmeter.plugins.exceptions.DatadogConfigurationException;
 import org.datadog.jmeter.plugins.metrics.DatadogMetric;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +49,12 @@ public class DatadogBackendClient extends AbstractBackendListenerClient implemen
     private DatadogHttpClient datadogClient;
 
     /**
+     * An instance of {@link DatadogConfiguration}.
+     * Instantiated during the test set up phase and contains the plugin configuration.
+     */
+    private DatadogConfiguration configuration;
+
+    /**
      * An instance of {@link ConcurrentAggregator}.
      * Instantiated upon creation of the DatadogBackendClient class. Aggregates metrics until instructed to flush.
      * Flushing occurs at a fixed schedule rate, @see {@link #timerHandle} and {@link #METRICS_SEND_INTERVAL}.
@@ -55,7 +63,7 @@ public class DatadogBackendClient extends AbstractBackendListenerClient implemen
 
     /**
      * An list of JSON log payloads to buffer calls to the Datadog API. Unlike metrics, logs are not aggregated before being sent. Thus
-     * flushing of logs doesn't occur at a fixed time interval but rather once the buffer is bigger than {@link #logsBatchSize}.
+     * flushing of logs doesn't occur at a fixed time interval but rather once the buffer is bigger than {@link DatadogConfiguration#getLogsBatchSize()}.
      */
     private List<JSONObject> logsBuffer = new ArrayList<>();
 
@@ -76,56 +84,6 @@ public class DatadogBackendClient extends AbstractBackendListenerClient implemen
      */
     private ScheduledFuture<?> timerHandle;
 
-
-    /**
-     * User configurable. This option configures how many metrics are sent in the same http request to Datadog.
-     * NOTE: Metrics are always sent at a fixed interval. This field configures how many API calls will be perfomed at the end of
-     * said interval.
-     */
-    private int metricsBatchSize = DEFAULT_METRICS_BATCH_SIZE;
-
-    /**
-     * User configurable. This option configures the size of the logs buffer. The bigger the value, the more logs will be kept in memory
-     * before being sent to Datadog and the bigger the resulting api call will be. Once that buffer size is reached, all pending log events
-     * are sent.
-     */
-    private int logsBatchSize = DEFAULT_LOGS_BATCH_SIZE;
-
-    /**
-     * User configurable. This options configures whether or not the plugin should submit individual results as Datadog logs.
-     */
-    private boolean sendResultsAsLogs = DEFAULT_SEND_RESULTS_AS_LOGS;
-
-    /**
-     * User configurable. This options configures whether or not to collect metrics and logs for jmeter subresults.
-     */
-    private boolean includeSubResults = DEFAULT_INCLUDE_SUB_RESULTS;
-
-    /**
-     * User configurable. This options configures which samplers to include in monitoring results using a regex
-     * that matches on the sampler name.
-     */
-    private Pattern samplersRegex = null;
-
-    /* The names of configuration options that are shown in JMeter UI */
-    private static final String API_URL_PARAM = "datadogUrl";
-    private static final String LOG_INTAKE_URL_PARAM = "logIntakeUrl";
-    private static final String API_KEY_PARAM = "apiKey";
-    private static final String METRICS_BATCH_SIZE = "metricsMaxBatchSize";
-    private static final String LOGS_BATCH_SIZE = "logsBatchSize";
-    private static final String SEND_RESULTS_AS_LOGS = "sendResultsAsLogs";
-    private static final String INCLUDE_SUB_RESULTS = "includeSubresults";
-    private static final String SAMPLERS_REGEX = "samplersRegex";
-
-    /* The default values for all configuration options */
-    private static final String DEFAULT_API_URL = "https://api.datadoghq.com/api/";
-    private static final String DEFAULT_LOG_INTAKE_URL = "https://http-intake.logs.datadoghq.com/v1/input/";
-    private static final int DEFAULT_METRICS_BATCH_SIZE = 200;
-    private static final int DEFAULT_LOGS_BATCH_SIZE = 500;
-    private static final boolean DEFAULT_SEND_RESULTS_AS_LOGS = true;
-    private static final boolean DEFAULT_INCLUDE_SUB_RESULTS = false;
-    private static final String DEFAULT_SAMPLERS_REGEX = "";
-
     /**
      * Calls at a fixed schedule and sends metrics to Datadog.
      */
@@ -140,62 +98,24 @@ public class DatadogBackendClient extends AbstractBackendListenerClient implemen
      */
     @Override
     public Arguments getDefaultParameters() {
-        Arguments arguments = new Arguments();
-        arguments.addArgument(API_KEY_PARAM, null);
-        arguments.addArgument(API_URL_PARAM, DEFAULT_API_URL);
-        arguments.addArgument(LOG_INTAKE_URL_PARAM, DEFAULT_LOG_INTAKE_URL);
-        arguments.addArgument(METRICS_BATCH_SIZE, String.valueOf(DEFAULT_METRICS_BATCH_SIZE));
-        arguments.addArgument(LOGS_BATCH_SIZE, String.valueOf(DEFAULT_LOGS_BATCH_SIZE));
-        arguments.addArgument(SEND_RESULTS_AS_LOGS, String.valueOf(DEFAULT_SEND_RESULTS_AS_LOGS));
-        arguments.addArgument(INCLUDE_SUB_RESULTS, String.valueOf(DEFAULT_INCLUDE_SUB_RESULTS));
-        arguments.addArgument(SAMPLERS_REGEX, DEFAULT_SAMPLERS_REGEX);
-
-        return arguments;
+        return DatadogConfiguration.getPluginArguments();
     }
 
     /**
      * Called before starting the test.
      * @param context An object used to fetch user configuration.
-     * @throws Exception If the configuration is invalid or if the plugin can't connect to Datadog.
+     * @throws DatadogConfigurationException If the configuration is invalid.
+     * @throws DatadogApiException If the plugin can't connect to Datadog.
      */
     @Override
     public void setupTest(BackendListenerContext context) throws Exception {
-        String apiKey = context.getParameter(API_KEY_PARAM);
-        String apiUrl = context.getParameter(API_URL_PARAM, DEFAULT_API_URL);
-        String logIntakeUrl = context.getParameter(LOG_INTAKE_URL_PARAM, DEFAULT_LOG_INTAKE_URL);
-        String metricsBatchSize = context.getParameter(METRICS_BATCH_SIZE, String.valueOf(DEFAULT_METRICS_BATCH_SIZE));
-        String logsBatchSize = context.getParameter(LOGS_BATCH_SIZE, String.valueOf(DEFAULT_LOGS_BATCH_SIZE));
-        String sendResultsAsLogs = context.getParameter(SEND_RESULTS_AS_LOGS, String.valueOf(DEFAULT_SEND_RESULTS_AS_LOGS));
-        String samplersRegex = context.getParameter(SAMPLERS_REGEX, DEFAULT_SAMPLERS_REGEX);
+        this.configuration = DatadogConfiguration.parseConfiguration(context);
 
-        if (apiKey == null) {
-            throw new Exception("apiKey needs to be configured.");
-        }
-
-        datadogClient = new DatadogHttpClient(apiKey, apiUrl, logIntakeUrl);
+        datadogClient = new DatadogHttpClient(configuration.getApiKey(), configuration.getApiUrl(), configuration.getLogIntakeUrl());
         boolean valid = datadogClient.validateConnection();
         if(!valid) {
-            throw new Exception("Invalid apiKey");
+            throw new DatadogApiException("Invalid apiKey");
         }
-
-        try {
-            this.metricsBatchSize = Integer.parseUnsignedInt(metricsBatchSize);
-        } catch (NumberFormatException e) {
-            throw new Exception("Invalid 'metricsBatchSize'. Value '" + metricsBatchSize + "' is not an integer.");
-        }
-
-        try {
-            this.logsBatchSize = Integer.parseUnsignedInt(logsBatchSize);
-        } catch (NumberFormatException e) {
-            throw new Exception("Invalid 'logsBatchSize'. Value '" + logsBatchSize + "' is not an integer.");
-        }
-
-        if(!sendResultsAsLogs.toLowerCase().equals("false") && !sendResultsAsLogs.toLowerCase().equals("true")) {
-            throw new Exception("Invalid 'sendResultsAsLogs'. Value '" + sendResultsAsLogs + "' is not a boolean.");
-        }
-        this.sendResultsAsLogs = Boolean.parseBoolean(sendResultsAsLogs);
-        this.samplersRegex = Pattern.compile(samplersRegex);
-        this.includeSubResults = context.getBooleanParameter(INCLUDE_SUB_RESULTS, DEFAULT_INCLUDE_SUB_RESULTS);
 
         scheduler = Executors.newScheduledThreadPool(1);
         this.timerHandle = scheduler.scheduleAtFixedRate(this, METRICS_SEND_INTERVAL, METRICS_SEND_INTERVAL, TimeUnit.SECONDS);
@@ -236,16 +156,15 @@ public class DatadogBackendClient extends AbstractBackendListenerClient implemen
     @Override
     public void handleSampleResults(List<SampleResult> list, BackendListenerContext backendListenerContext) {
         for (SampleResult sampleResult : list) {
-            Matcher matcher = samplersRegex.matcher(sampleResult.getSampleLabel());
+            Matcher matcher = configuration.getSamplersRegex().matcher(sampleResult.getSampleLabel());
             if(!matcher.find()) {
                 continue;
             }
-            if(this.includeSubResults) {
+            if(configuration.shouldIncludeSubResults()) {
                 for (SampleResult subResult : sampleResult.getSubResults()) {
                     this.extractData(subResult);
                 }
             } else {
-                // TODO: Should we also include this one even when includeSubResults is set?
                 this.extractData(sampleResult);
             }
         }
@@ -259,9 +178,9 @@ public class DatadogBackendClient extends AbstractBackendListenerClient implemen
         UserMetric userMetrics = this.getUserMetrics();
         userMetrics.add(sampleResult);
         this.extractMetrics(sampleResult);
-        if(this.sendResultsAsLogs) {
+        if(configuration.shouldSendResultsAsLogs()) {
             this.extractLogs(sampleResult);
-            if(logsBuffer.size() >= this.logsBatchSize) {
+            if(logsBuffer.size() >= configuration.getLogsBatchSize()) {
                 datadogClient.submitLogs(logsBuffer);
                 logsBuffer.clear();
             }
@@ -284,20 +203,10 @@ public class DatadogBackendClient extends AbstractBackendListenerClient implemen
             aggregator.incrementCounter("jmeter.responses_count", tags, sampleResult.getErrorCount());
         }
 
-        for(SampleResult r : sampleResult.getSubResults()) {
-            if(sampleResult.isSuccessful()) {
-                aggregator.incrementCounter("jmeter.responses_count", tags, sampleResult.getSampleCount() - sampleResult.getErrorCount());
-            } else {
-                aggregator.incrementCounter("jmeter.responses_count", tags, sampleResult.getErrorCount());
-            }
-        }
-        // TODO: Add responses count for each sub result
-        // TODO: Add request per second
         aggregator.histogram("jmeter.response_time", tags, sampleResult.getTime() / 1000f);
         aggregator.histogram("jmeter.bytes_sent", tags, sampleResult.getSentBytes());
         aggregator.histogram("jmeter.bytes_received", tags, sampleResult.getBytesAsLong());
         aggregator.histogram("jmeter.latency", tags, sampleResult.getLatency() / 1000f);
-
     }
 
     /**
@@ -356,7 +265,7 @@ public class DatadogBackendClient extends AbstractBackendListenerClient implemen
         List<DatadogMetric> metrics = aggregator.flushMetrics();
 
         AtomicInteger counter = new AtomicInteger();
-        metrics.stream().collect(Collectors.groupingBy(it -> counter.getAndIncrement() / this.metricsBatchSize)).values().forEach(
+        metrics.stream().collect(Collectors.groupingBy(it -> counter.getAndIncrement() / configuration.getMetricsMaxBatchSize())).values().forEach(
                 x -> datadogClient.submitMetrics(x)
         );
     }

--- a/src/main/java/org/datadog/jmeter/plugins/DatadogConfiguration.java
+++ b/src/main/java/org/datadog/jmeter/plugins/DatadogConfiguration.java
@@ -1,0 +1,165 @@
+package org.datadog.jmeter.plugins;
+
+import java.util.regex.Pattern;
+import org.apache.jmeter.config.Arguments;
+import org.apache.jmeter.visualizers.backend.BackendListenerContext;
+import org.datadog.jmeter.plugins.exceptions.DatadogConfigurationException;
+
+
+public class DatadogConfiguration {
+
+    /**
+     * The Datadog api key to use for submitting metrics and logs.
+     */
+    private String apiKey;
+
+    /**
+     * The Datadog api url to use for submitting metrics.
+     */
+    private String apiUrl;
+
+    /**
+     * The Datadog api url to use for submitting logs.
+     */
+    private String logIntakeUrl;
+
+    /**
+     * This option configures how many metrics are sent in the same http request to Datadog.
+     * NOTE: Metrics are always sent at a fixed interval. This field configures how many API calls will be perfomed at the end of
+     * said interval.
+     */
+    private int metricsMaxBatchSize;
+
+    /**
+     * This option configures the size of the logs buffer. The bigger the value, the more logs will be kept in memory
+     * before being sent to Datadog and the bigger the resulting api call will be. Once that buffer size is reached, all pending log events
+     * are sent.
+     */
+    private int logsBatchSize;
+
+    /**
+     * This options configures whether or not the plugin should submit individual results as Datadog logs.
+     */
+    private boolean sendResultsAsLogs;
+
+    /**
+     * This options configures whether or not to collect metrics and logs for jmeter subresults.
+     */
+    private boolean includeSubResults;
+
+    /**
+     * User configurable. This options configures which samplers to include in monitoring results using a regex
+     * that matches on the sampler name.
+     */
+    private Pattern samplersRegex = null;
+
+    /* The names of configuration options that are shown in JMeter UI */
+    private static final String API_URL_PARAM = "datadogUrl";
+    private static final String LOG_INTAKE_URL_PARAM = "logIntakeUrl";
+    private static final String API_KEY_PARAM = "apiKey";
+    private static final String METRICS_MAX_BATCH_SIZE = "metricsMaxBatchSize";
+    private static final String LOGS_BATCH_SIZE = "logsBatchSize";
+    private static final String SEND_RESULTS_AS_LOGS = "sendResultsAsLogs";
+    private static final String INCLUDE_SUB_RESULTS = "includeSubresults";
+    private static final String SAMPLERS_REGEX = "samplersRegex";
+
+    /* The default values for all configuration options */
+    private static final String DEFAULT_API_URL = "https://api.datadoghq.com/api/";
+    private static final String DEFAULT_LOG_INTAKE_URL = "https://http-intake.logs.datadoghq.com/v1/input/";
+    private static final int DEFAULT_METRICS_MAX_BATCH_SIZE = 200;
+    private static final int DEFAULT_LOGS_BATCH_SIZE = 500;
+    private static final boolean DEFAULT_SEND_RESULTS_AS_LOGS = true;
+    private static final boolean DEFAULT_INCLUDE_SUB_RESULTS = false;
+    private static final String DEFAULT_SAMPLERS_REGEX = "";
+
+    private DatadogConfiguration(){}
+
+    public static Arguments getPluginArguments() {
+        Arguments arguments = new Arguments();
+        arguments.addArgument(API_KEY_PARAM, null);
+        arguments.addArgument(API_URL_PARAM, DEFAULT_API_URL);
+        arguments.addArgument(LOG_INTAKE_URL_PARAM, DEFAULT_LOG_INTAKE_URL);
+        arguments.addArgument(METRICS_MAX_BATCH_SIZE, String.valueOf(DEFAULT_METRICS_MAX_BATCH_SIZE));
+        arguments.addArgument(LOGS_BATCH_SIZE, String.valueOf(DEFAULT_LOGS_BATCH_SIZE));
+        arguments.addArgument(SEND_RESULTS_AS_LOGS, String.valueOf(DEFAULT_SEND_RESULTS_AS_LOGS));
+        arguments.addArgument(INCLUDE_SUB_RESULTS, String.valueOf(DEFAULT_INCLUDE_SUB_RESULTS));
+        arguments.addArgument(SAMPLERS_REGEX, DEFAULT_SAMPLERS_REGEX);
+
+        return arguments;
+    }
+
+    public static DatadogConfiguration parseConfiguration(BackendListenerContext context) throws DatadogConfigurationException {
+        DatadogConfiguration configuration = new DatadogConfiguration();
+
+        String apiKey = context.getParameter(API_KEY_PARAM);
+        if (apiKey == null) {
+            throw new DatadogConfigurationException("apiKey needs to be configured.");
+        }
+        configuration.apiKey = apiKey;
+
+        configuration.apiUrl = context.getParameter(API_URL_PARAM, DEFAULT_API_URL);
+        configuration.logIntakeUrl = context.getParameter(LOG_INTAKE_URL_PARAM, DEFAULT_LOG_INTAKE_URL);
+
+
+        String metricsMaxBatchSize = context.getParameter(METRICS_MAX_BATCH_SIZE, String.valueOf(DEFAULT_METRICS_MAX_BATCH_SIZE));
+        try {
+            configuration.metricsMaxBatchSize = Integer.parseUnsignedInt(metricsMaxBatchSize);
+        } catch (NumberFormatException e) {
+            throw new DatadogConfigurationException("Invalid 'metricsMaxBatchSize'. Value '" + metricsMaxBatchSize + "' is not an integer.");
+        }
+
+        String logsBatchSize = context.getParameter(LOGS_BATCH_SIZE, String.valueOf(DEFAULT_LOGS_BATCH_SIZE));
+        try {
+            configuration.logsBatchSize = Integer.parseUnsignedInt(logsBatchSize);
+        } catch (NumberFormatException e) {
+            throw new DatadogConfigurationException("Invalid 'logsBatchSize'. Value '" + logsBatchSize + "' is not an integer.");
+        }
+
+        String sendResultsAsLogs = context.getParameter(SEND_RESULTS_AS_LOGS, String.valueOf(DEFAULT_SEND_RESULTS_AS_LOGS));
+        if(!sendResultsAsLogs.toLowerCase().equals("false") && !sendResultsAsLogs.toLowerCase().equals("true")) {
+            throw new DatadogConfigurationException("Invalid 'sendResultsAsLogs'. Value '" + sendResultsAsLogs + "' is not a boolean.");
+        }
+        configuration.sendResultsAsLogs = Boolean.parseBoolean(sendResultsAsLogs);
+
+        String includeSubResults = context.getParameter(INCLUDE_SUB_RESULTS, String.valueOf(DEFAULT_INCLUDE_SUB_RESULTS));
+        if(!includeSubResults.toLowerCase().equals("false") && !includeSubResults.toLowerCase().equals("true")) {
+            throw new DatadogConfigurationException("Invalid 'includeSubResults'. Value '" + includeSubResults + "' is not a boolean.");
+        }
+        configuration.includeSubResults = Boolean.parseBoolean(includeSubResults);
+        configuration.samplersRegex = Pattern.compile(context.getParameter(SAMPLERS_REGEX, DEFAULT_SAMPLERS_REGEX));
+
+        return configuration;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public String getApiUrl() {
+        return apiUrl;
+    }
+
+    public String getLogIntakeUrl() {
+        return logIntakeUrl;
+    }
+
+    public int getMetricsMaxBatchSize() {
+        return metricsMaxBatchSize;
+    }
+
+    public int getLogsBatchSize() {
+        return logsBatchSize;
+    }
+
+    public boolean shouldSendResultsAsLogs() {
+        return sendResultsAsLogs;
+    }
+
+    public boolean shouldIncludeSubResults() {
+        return includeSubResults;
+    }
+
+    public Pattern getSamplersRegex() {
+        return samplersRegex;
+    }
+}

--- a/src/main/java/org/datadog/jmeter/plugins/exceptions/DatadogApiException.java
+++ b/src/main/java/org/datadog/jmeter/plugins/exceptions/DatadogApiException.java
@@ -1,0 +1,8 @@
+package org.datadog.jmeter.plugins.exceptions;
+
+public class DatadogApiException extends Exception {
+    public DatadogApiException(String message){
+        super(message);
+    }
+
+}

--- a/src/main/java/org/datadog/jmeter/plugins/exceptions/DatadogConfigurationException.java
+++ b/src/main/java/org/datadog/jmeter/plugins/exceptions/DatadogConfigurationException.java
@@ -1,0 +1,7 @@
+package org.datadog.jmeter.plugins.exceptions;
+
+public class DatadogConfigurationException extends Exception {
+    public DatadogConfigurationException(String message){
+        super(message);
+    }
+}

--- a/src/test/java/org/datadog/jmeter/plugins/DatadogBackendClientTest.java
+++ b/src/test/java/org/datadog/jmeter/plugins/DatadogBackendClientTest.java
@@ -5,21 +5,192 @@
 
 package org.datadog.jmeter.plugins;
 
-import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.minidev.json.JSONObject;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.visualizers.backend.BackendListenerContext;
+import org.datadog.jmeter.plugins.aggregation.ConcurrentAggregator;
+import org.datadog.jmeter.plugins.metrics.DatadogMetric;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * Unit test for simple App.
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(DatadogBackendClient.class)
+@PowerMockIgnore({
+        "javax.management.*",
+        "javax.script.*"
+})
 public class DatadogBackendClientTest
 {
-    /**
-     * Rigorous Test :-)
-     */
-    @Test
-    public void shouldAnswerWithTrue()
-    {
-        assertTrue( true );
+    private DatadogBackendClient client;
+    private Map<String, String> DEFAULT_VALID_TEST_CONFIG = new HashMap<String, String>() {
+        {
+            put("apiKey", "123456");
+            put("datadogUrl", "datadogUrl");
+            put("logIntakeUrl", "logIntakeUrl");
+            put("metricsMaxBatchSize", "10");
+            put("logsBatchSize", "0");
+            put("sendResultsAsLogs", "true");
+            put("includeSubresults", "false");
+            put("samplersRegex", "^foo\\d*$");
+        }
+    };
+    private ConcurrentAggregator aggregator = new ConcurrentAggregator();
+    private BackendListenerContext context = new BackendListenerContext(DEFAULT_VALID_TEST_CONFIG);
+    private List<JSONObject> logsBuffer;
+    @Before
+    public void setUpMocks() throws Exception {
+        logsBuffer = new ArrayList<>();
+        DatadogHttpClient httpClientMock = PowerMockito.mock(DatadogHttpClient.class);
+        PowerMockito.whenNew(ConcurrentAggregator.class).withAnyArguments().thenReturn(aggregator);
+        PowerMockito.whenNew(DatadogHttpClient.class).withAnyArguments().thenReturn(httpClientMock);
+        PowerMockito.when(httpClientMock.validateConnection()).thenReturn(true);
+        PowerMockito.doAnswer((e) -> logsBuffer.addAll(e.getArgument(0))).when(httpClientMock).submitLogs(any());
+        client = new DatadogBackendClient();
+        client.setupTest(context);
     }
+
+    @After
+    public void teardownMocks() throws Exception {
+        client.teardownTest(context);
+        logsBuffer.clear();
+    }
+
+
+
+    private SampleResult createDummySampleResult(String sampleLabel) {
+        SampleResult result = SampleResult.createTestSample(1, 126);
+        result.setSuccessful(true);
+        result.setResponseCode("123");
+        result.setSampleLabel(sampleLabel);
+        result.setSampleCount(10);
+        result.setErrorCount(1);
+        result.setSentBytes(124);
+        result.setBytes((long)12345);
+        result.setLatency(12);
+        return result;
+    }
+
+    @Test
+    public void testExtractMetrics() {
+        SampleResult result = createDummySampleResult("foo");
+        this.client.handleSampleResults(Collections.singletonList(result), context);
+        List<DatadogMetric> metrics = this.aggregator.flushMetrics();
+        String[] expectedTags = new String[] {"response_code:123", "sample_label:foo", "result:ok"};
+        String[] expectedMetricNames = new String[] {
+                "jmeter.responses_count",
+                "jmeter.latency.max",
+                "jmeter.latency.min",
+                "jmeter.latency.p99",
+                "jmeter.latency.p95",
+                "jmeter.latency.p90",
+                "jmeter.latency.avg",
+                "jmeter.latency.count",
+                "jmeter.response_time.max",
+                "jmeter.response_time.min",
+                "jmeter.response_time.p99",
+                "jmeter.response_time.p95",
+                "jmeter.response_time.p90",
+                "jmeter.response_time.avg",
+                "jmeter.response_time.count",
+                "jmeter.bytes_received.max",
+                "jmeter.bytes_received.min",
+                "jmeter.bytes_received.p99",
+                "jmeter.bytes_received.p95",
+                "jmeter.bytes_received.p90",
+                "jmeter.bytes_received.avg",
+                "jmeter.bytes_received.count",
+                "jmeter.bytes_sent.max",
+                "jmeter.bytes_sent.min",
+                "jmeter.bytes_sent.p99",
+                "jmeter.bytes_sent.p95",
+                "jmeter.bytes_sent.p90",
+                "jmeter.bytes_sent.avg",
+                "jmeter.bytes_sent.count",
+        };
+        double[] expectedMetricValues = new double[] {
+                10.0,
+                0.01195256210245945,
+                0.01195256210245945,
+                0.01195256210245945,
+                0.01195256210245945,
+                0.01195256210245945,
+                0.012000000104308128,
+                1.0,
+                0.12624150202599055,
+                0.12624150202599055,
+                0.12624150202599055,
+                0.12624150202599055,
+                0.12624150202599055,
+                0.125,
+                1.0,
+                12291.916561360777,
+                12291.916561360777,
+                12291.916561360777,
+                12291.916561360777,
+                12291.916561360777,
+                12345.0,
+                1.0,
+                124.37724692430666,
+                124.37724692430666,
+                124.37724692430666,
+                124.37724692430666,
+                124.37724692430666,
+                124.0,
+                1.0,
+        };
+
+        for(int i = 0; i < expectedMetricNames.length; i++){
+            DatadogMetric metric = metrics.get(i);
+            Assert.assertEquals(expectedMetricNames[i], metric.getName());
+            Assert.assertArrayEquals(expectedTags, metric.getTags());
+            if(metric.getName().endsWith("count")) {
+                Assert.assertEquals("count", metric.getType());
+            } else {
+                Assert.assertEquals("gauge", metric.getType());
+            }
+            Assert.assertEquals(expectedMetricValues[i], metric.getValue(), 1e-12);
+        }
+    }
+
+    @Test
+    public void testExtractLogs() {
+        SampleResult result = createDummySampleResult("foo");
+        this.client.handleSampleResults(Collections.singletonList(result), context);
+        Assert.assertEquals(1, this.logsBuffer.size());
+        String expectedPayload = "{\"sample_start_time\":1.0,\"response_code\":\"123\",\"headers_size\":0.0,\"sample_label\":\"foo\",\"latency\":12.0,\"group_threads\":0.0,\"idle_time\":0.0,\"error_count\":0.0,\"message\":\"\",\"url\":\"\",\"ddsource\":\"jmeter\",\"sent_bytes\":124.0,\"body_size\":0.0,\"content_type\":\"\",\"load_time\":125.0,\"thread_name\":\"\",\"sample_end_time\":126.0,\"bytes\":12345.0,\"connect_time\":0.0,\"sample_count\":10.0,\"data_type\":\"\",\"all_threads\":0.0,\"data_encoding\":null}";
+        Assert.assertEquals(this.logsBuffer.get(0).toString(), expectedPayload);
+    }
+
+    @Test
+    public void testRegexNotMatching() {
+        SampleResult result1 = createDummySampleResult("foo1");
+        SampleResult resultA = createDummySampleResult("fooA");
+
+        this.client.handleSampleResults(Arrays.asList(result1, resultA), context);
+        String[] expectedTagsResult1 = new String[] {"response_code:123", "sample_label:foo1", "result:ok"};
+        for(DatadogMetric metric : this.aggregator.flushMetrics()){
+            Assert.assertArrayEquals(expectedTagsResult1, metric.getTags());
+        }
+        Assert.assertEquals(1, this.logsBuffer.size());
+        Assert.assertEquals("foo1", this.logsBuffer.get(0).getAsString("sample_label"));
+    }
+
 }

--- a/src/test/java/org/datadog/jmeter/plugins/DatadogConfigurationTest.java
+++ b/src/test/java/org/datadog/jmeter/plugins/DatadogConfigurationTest.java
@@ -1,0 +1,146 @@
+package org.datadog.jmeter.plugins;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.PatternSyntaxException;
+import org.apache.jmeter.config.Arguments;
+import org.apache.jmeter.visualizers.backend.BackendListenerContext;
+import org.datadog.jmeter.plugins.exceptions.DatadogConfigurationException;
+import org.junit.Test;
+import org.junit.Assert;
+
+public class DatadogConfigurationTest {
+    private static final String API_URL_PARAM = "datadogUrl";
+    private static final String LOG_INTAKE_URL_PARAM = "logIntakeUrl";
+    private static final String API_KEY_PARAM = "apiKey";
+    private static final String METRICS_MAX_BATCH_SIZE = "metricsMaxBatchSize";
+    private static final String LOGS_BATCH_SIZE = "logsBatchSize";
+    private static final String SEND_RESULTS_AS_LOGS = "sendResultsAsLogs";
+    private static final String INCLUDE_SUB_RESULTS = "includeSubresults";
+    private static final String SAMPLERS_REGEX = "samplersRegex";
+
+    @Test
+    public void testArguments(){
+        Arguments args = DatadogConfiguration.getPluginArguments();
+        Assert.assertEquals(8, args.getArgumentCount());
+
+        Map<String, String> argumentsMap = args.getArgumentsAsMap();
+        Assert.assertTrue(argumentsMap.containsKey(API_URL_PARAM));
+        Assert.assertTrue(argumentsMap.containsKey(LOG_INTAKE_URL_PARAM));
+        Assert.assertTrue(argumentsMap.containsKey(API_KEY_PARAM));
+        Assert.assertTrue(argumentsMap.containsKey(METRICS_MAX_BATCH_SIZE));
+        Assert.assertTrue(argumentsMap.containsKey(LOGS_BATCH_SIZE));
+        Assert.assertTrue(argumentsMap.containsKey(SEND_RESULTS_AS_LOGS));
+        Assert.assertTrue(argumentsMap.containsKey(INCLUDE_SUB_RESULTS));
+        Assert.assertTrue(argumentsMap.containsKey(SAMPLERS_REGEX));
+    }
+
+    @Test
+    public void testValidConfiguration() throws DatadogConfigurationException {
+        Map<String, String> config = new HashMap<String, String>() {
+            {
+                put(API_KEY_PARAM, "123456");
+                put(API_URL_PARAM, "datadogUrl");
+                put(LOG_INTAKE_URL_PARAM, "logIntakeUrl");
+                put(METRICS_MAX_BATCH_SIZE, "10");
+                put(LOGS_BATCH_SIZE, "11");
+                put(SEND_RESULTS_AS_LOGS, "true");
+                put(INCLUDE_SUB_RESULTS, "false");
+                put(SAMPLERS_REGEX, "false");
+            }
+        };
+
+        BackendListenerContext context = new BackendListenerContext(config);
+        DatadogConfiguration datadogConfiguration = DatadogConfiguration.parseConfiguration(context);
+
+        Assert.assertEquals("123456", datadogConfiguration.getApiKey());
+        Assert.assertEquals("datadogUrl", datadogConfiguration.getApiUrl());
+        Assert.assertEquals("logIntakeUrl", datadogConfiguration.getLogIntakeUrl());
+        Assert.assertEquals(10, datadogConfiguration.getMetricsMaxBatchSize());
+        Assert.assertEquals(11, datadogConfiguration.getLogsBatchSize());
+        Assert.assertTrue(datadogConfiguration.shouldSendResultsAsLogs());
+        Assert.assertFalse(datadogConfiguration.shouldIncludeSubResults());
+    }
+
+    @Test(expected = DatadogConfigurationException.class)
+    public void testMissingApiKey() throws DatadogConfigurationException {
+        Map<String, String> config = new HashMap<>();
+        DatadogConfiguration.parseConfiguration(new BackendListenerContext(config));
+    }
+
+    @Test
+    public void testApiKeyIsTheOnlyRequiredParam() throws DatadogConfigurationException {
+        Map<String, String> config = new HashMap<String, String>() {
+            {
+                put("apiKey", "123456");
+            }
+        };
+        DatadogConfiguration.parseConfiguration(new BackendListenerContext(config));
+    }
+
+    @Test(expected = DatadogConfigurationException.class)
+    public void testMetricsBatchSizeNotInt() throws DatadogConfigurationException {
+        Map<String, String> config = new HashMap<String, String>() {
+            {
+                put("apiKey", "123456");
+                put("metricsMaxBatchSize", "foo");
+            }
+        };
+        DatadogConfiguration.parseConfiguration(new BackendListenerContext(config));
+    }
+
+    @Test(expected = DatadogConfigurationException.class)
+    public void testLogsBatchSizeNotInt() throws DatadogConfigurationException {
+        Map<String, String> config = new HashMap<String, String>() {
+            {
+                put("apiKey", "123456");
+                put("logsBatchSize", "foo");
+            }
+        };
+        DatadogConfiguration.parseConfiguration(new BackendListenerContext(config));
+    }
+
+    @Test(expected = DatadogConfigurationException.class)
+    public void testSendResultsAsLogsNotBoolean() throws DatadogConfigurationException {
+        Map<String, String> config = new HashMap<String, String>() {
+            {
+                put("apiKey", "123456");
+                put("sendResultsAsLogs", "foo");
+            }
+        };
+        DatadogConfiguration.parseConfiguration(new BackendListenerContext(config));
+    }
+
+    @Test(expected = DatadogConfigurationException.class)
+    public void testIncludeSubresultsNotBoolean() throws DatadogConfigurationException {
+        Map<String, String> config = new HashMap<String, String>() {
+            {
+                put("apiKey", "123456");
+                put("includeSubresults", "foo");
+            }
+        };
+        DatadogConfiguration.parseConfiguration(new BackendListenerContext(config));
+    }
+
+    @Test(expected = PatternSyntaxException.class)
+    public void testInvalidRegex() throws DatadogConfigurationException {
+        Map<String, String> config = new HashMap<String, String>() {
+            {
+                put("apiKey", "123456");
+                put(SAMPLERS_REGEX, "[");
+            }
+        };
+        DatadogConfiguration.parseConfiguration(new BackendListenerContext(config));
+    }
+
+    @Test
+    public void testValidRegex() throws DatadogConfigurationException {
+        Map<String, String> config = new HashMap<String, String>() {
+            {
+                put("apiKey", "123456");
+                put(SAMPLERS_REGEX, "[asd]\\d+");
+            }
+        };
+        DatadogConfiguration.parseConfiguration(new BackendListenerContext(config));
+    }
+}


### PR DESCRIPTION
Creates a new class called DatadogConfiguration that handles reading and parsing configuration elements. This simplifies the main DatadogBackendClient class and allows the class to be more easily tested.

This PR also adds more tests overall