### PR TITLE
Add `customTags` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The plugin has the following configuration options:
 |logsBatchSize|false|500|Logs are submitted in batches of size `logsBatchSize` as soon as this size is reached.|
 |sendResultsAsLogs|false|false|By default only metrics are reported to Datadog. To report individual test results as log events, set this field to `true`.|
 |includeSubresults|false|false|A subresult is for instance when an individual HTTP request has to follow redirects. By default subresults are ignored.|
-|tagsToBeUsed|false|key1:value1,key2:value2|Tags to be sent during performance - keys and values to be seperated by '"' and different items to be seperated by ","
+|customTags|false|`""`|Comma-separated list of tags to add to every metric
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The plugin has the following configuration options:
 |logsBatchSize|false|500|Logs are submitted in batches of size `logsBatchSize` as soon as this size is reached.|
 |sendResultsAsLogs|false|false|By default only metrics are reported to Datadog. To report individual test results as log events, set this field to `true`.|
 |includeSubresults|false|false|A subresult is for instance when an individual HTTP request has to follow redirects. By default subresults are ignored.|
+|tagsToBeUsed|false|key1:value1,key2:value2|Tags to be sent during performance - keys and values to be seperated by '"' and different items to be seperated by ","
 
 ## Contributing
 

--- a/src/main/java/org/datadog/jmeter/plugins/DatadogBackendClient.java
+++ b/src/main/java/org/datadog/jmeter/plugins/DatadogBackendClient.java
@@ -111,7 +111,7 @@ public class DatadogBackendClient extends AbstractBackendListenerClient implemen
     public void setupTest(BackendListenerContext context) throws Exception {
         this.configuration = DatadogConfiguration.parseConfiguration(context);
 
-        datadogClient = new DatadogHttpClient(configuration.getApiKey(), configuration.getApiUrl(), configuration.getLogIntakeUrl());
+        datadogClient = new DatadogHttpClient(configuration.getApiKey(), configuration.getApiUrl(), configuration.getLogIntakeUrl(),configuration.getInputTags());
         boolean valid = datadogClient.validateConnection();
         if(!valid) {
             throw new DatadogApiException("Invalid apiKey");

--- a/src/main/java/org/datadog/jmeter/plugins/DatadogConfiguration.java
+++ b/src/main/java/org/datadog/jmeter/plugins/DatadogConfiguration.java
@@ -5,6 +5,8 @@
 
 package org.datadog.jmeter.plugins;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Pattern;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.visualizers.backend.BackendListenerContext;
@@ -58,6 +60,12 @@ public class DatadogConfiguration {
      */
     private Pattern samplersRegex = null;
 
+    /**
+     * User configurable. This options configures which tags that are needed during a performance test
+     */
+    private List<String> inputTags;
+
+
     /* The names of configuration options that are shown in JMeter UI */
     private static final String API_URL_PARAM = "datadogUrl";
     private static final String LOG_INTAKE_URL_PARAM = "logIntakeUrl";
@@ -67,6 +75,7 @@ public class DatadogConfiguration {
     private static final String SEND_RESULTS_AS_LOGS = "sendResultsAsLogs";
     private static final String INCLUDE_SUB_RESULTS = "includeSubresults";
     private static final String SAMPLERS_REGEX = "samplersRegex";
+    private static final String INPUT_TAGS ="tagsToBeUsed";
 
     /* The default values for all configuration options */
     private static final String DEFAULT_API_URL = "https://api.datadoghq.com/api/";
@@ -76,6 +85,7 @@ public class DatadogConfiguration {
     private static final boolean DEFAULT_SEND_RESULTS_AS_LOGS = true;
     private static final boolean DEFAULT_INCLUDE_SUB_RESULTS = false;
     private static final String DEFAULT_SAMPLERS_REGEX = "";
+    private static final String DEFAULT_INPUT_TAGS = "key1:value1,key2:value2";
 
     private DatadogConfiguration(){}
 
@@ -89,12 +99,24 @@ public class DatadogConfiguration {
         arguments.addArgument(SEND_RESULTS_AS_LOGS, String.valueOf(DEFAULT_SEND_RESULTS_AS_LOGS));
         arguments.addArgument(INCLUDE_SUB_RESULTS, String.valueOf(DEFAULT_INCLUDE_SUB_RESULTS));
         arguments.addArgument(SAMPLERS_REGEX, DEFAULT_SAMPLERS_REGEX);
-
+        arguments.addArgument(INPUT_TAGS, DEFAULT_INPUT_TAGS);
         return arguments;
     }
 
     public static DatadogConfiguration parseConfiguration(BackendListenerContext context) throws DatadogConfigurationException {
         DatadogConfiguration configuration = new DatadogConfiguration();
+        List<String> inputTags = new ArrayList<>();
+        if(!context.getParameter(INPUT_TAGS).contains(":")){
+            inputTags.add("");
+        }else if(context.getParameter(INPUT_TAGS).contains(",")){
+            for (String item:context.getParameter(INPUT_TAGS).split(",")) {
+                inputTags.add(item);
+            }
+        }else{
+            inputTags.add(context.getParameter(INPUT_TAGS));
+        }
+
+        configuration.inputTags = inputTags;
 
         String apiKey = context.getParameter(API_KEY_PARAM);
         if (apiKey == null) {
@@ -166,5 +188,9 @@ public class DatadogConfiguration {
 
     public Pattern getSamplersRegex() {
         return samplersRegex;
+    }
+
+    public List<String> getInputTags(){
+        return inputTags;
     }
 }

--- a/src/main/java/org/datadog/jmeter/plugins/DatadogConfiguration.java
+++ b/src/main/java/org/datadog/jmeter/plugins/DatadogConfiguration.java
@@ -63,7 +63,7 @@ public class DatadogConfiguration {
     /**
      * User configurable. This options configures which tags that are needed during a performance test
      */
-    private List<String> inputTags;
+    private List<String> customTags;
 
 
     /* The names of configuration options that are shown in JMeter UI */
@@ -75,7 +75,7 @@ public class DatadogConfiguration {
     private static final String SEND_RESULTS_AS_LOGS = "sendResultsAsLogs";
     private static final String INCLUDE_SUB_RESULTS = "includeSubresults";
     private static final String SAMPLERS_REGEX = "samplersRegex";
-    private static final String INPUT_TAGS ="tagsToBeUsed";
+    private static final String CUSTOM_TAGS ="customTags";
 
     /* The default values for all configuration options */
     private static final String DEFAULT_API_URL = "https://api.datadoghq.com/api/";
@@ -85,7 +85,7 @@ public class DatadogConfiguration {
     private static final boolean DEFAULT_SEND_RESULTS_AS_LOGS = true;
     private static final boolean DEFAULT_INCLUDE_SUB_RESULTS = false;
     private static final String DEFAULT_SAMPLERS_REGEX = "";
-    private static final String DEFAULT_INPUT_TAGS = "key1:value1,key2:value2";
+    private static final String DEFAULT_CUSTOM_TAGS = "";
 
     private DatadogConfiguration(){}
 
@@ -99,24 +99,12 @@ public class DatadogConfiguration {
         arguments.addArgument(SEND_RESULTS_AS_LOGS, String.valueOf(DEFAULT_SEND_RESULTS_AS_LOGS));
         arguments.addArgument(INCLUDE_SUB_RESULTS, String.valueOf(DEFAULT_INCLUDE_SUB_RESULTS));
         arguments.addArgument(SAMPLERS_REGEX, DEFAULT_SAMPLERS_REGEX);
-        arguments.addArgument(INPUT_TAGS, DEFAULT_INPUT_TAGS);
+        arguments.addArgument(CUSTOM_TAGS, DEFAULT_CUSTOM_TAGS);
         return arguments;
     }
 
     public static DatadogConfiguration parseConfiguration(BackendListenerContext context) throws DatadogConfigurationException {
         DatadogConfiguration configuration = new DatadogConfiguration();
-        List<String> inputTags = new ArrayList<>();
-        if(!context.getParameter(INPUT_TAGS).contains(":")){
-            inputTags.add("");
-        }else if(context.getParameter(INPUT_TAGS).contains(",")){
-            for (String item:context.getParameter(INPUT_TAGS).split(",")) {
-                inputTags.add(item);
-            }
-        }else{
-            inputTags.add(context.getParameter(INPUT_TAGS));
-        }
-
-        configuration.inputTags = inputTags;
 
         String apiKey = context.getParameter(API_KEY_PARAM);
         if (apiKey == null) {
@@ -155,6 +143,18 @@ public class DatadogConfiguration {
         configuration.includeSubResults = Boolean.parseBoolean(includeSubResults);
         configuration.samplersRegex = Pattern.compile(context.getParameter(SAMPLERS_REGEX, DEFAULT_SAMPLERS_REGEX));
 
+        String customTagsString = context.getParameter(CUSTOM_TAGS, String.valueOf(DEFAULT_CUSTOM_TAGS));
+        List<String> customTags = new ArrayList<>();
+        if(customTagsString.contains(",")){
+            for (String item:customTagsString.split(",")) {
+                customTags.add(item);
+            }
+        }else if(!customTagsString.equals("")){
+            customTags.add(customTagsString);
+        }
+
+        configuration.customTags = customTags;
+
         return configuration;
     }
 
@@ -190,7 +190,7 @@ public class DatadogConfiguration {
         return samplersRegex;
     }
 
-    public List<String> getInputTags(){
-        return inputTags;
+    public List<String> getCustomTags(){
+        return customTags;
     }
 }

--- a/src/main/java/org/datadog/jmeter/plugins/DatadogHttpClient.java
+++ b/src/main/java/org/datadog/jmeter/plugins/DatadogHttpClient.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
  */
 public class DatadogHttpClient {
     private String apiKey;
-    private List<String> inputTags;
     private static final Logger logger = LoggerFactory.getLogger(DatadogHttpClient.class);
     private static final String METRIC = "v1/series";
     private static final String VALIDATE = "v1/validate";
@@ -40,11 +39,10 @@ public class DatadogHttpClient {
      * @param apiUrl the api url
      * @param logIntakeUrl the log intake url
      */
-    public DatadogHttpClient(String apiKey, String apiUrl, String logIntakeUrl, List<String> inputTags) {
+    public DatadogHttpClient(String apiKey, String apiUrl, String logIntakeUrl) {
         this.apiKey = apiKey;
         this.apiUrl = apiUrl;
         this.logIntakeUrl = logIntakeUrl;
-        this.inputTags = inputTags;
     }
 
     /**
@@ -101,9 +99,6 @@ public class DatadogHttpClient {
             points.add(point);
 
             JSONArray tags = new JSONArray();
-            for (String item:this.inputTags) {
-                tags.add(item);
-            }
             tags.addAll(Arrays.asList(datadogMetric.getTags()));
 
             JSONObject metric = new JSONObject();

--- a/src/main/java/org/datadog/jmeter/plugins/DatadogHttpClient.java
+++ b/src/main/java/org/datadog/jmeter/plugins/DatadogHttpClient.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DatadogHttpClient {
     private String apiKey;
+    private List<String> inputTags;
     private static final Logger logger = LoggerFactory.getLogger(DatadogHttpClient.class);
     private static final String METRIC = "v1/series";
     private static final String VALIDATE = "v1/validate";
@@ -39,10 +40,11 @@ public class DatadogHttpClient {
      * @param apiUrl the api url
      * @param logIntakeUrl the log intake url
      */
-    public DatadogHttpClient(String apiKey, String apiUrl, String logIntakeUrl) {
+    public DatadogHttpClient(String apiKey, String apiUrl, String logIntakeUrl, List<String> inputTags) {
         this.apiKey = apiKey;
         this.apiUrl = apiUrl;
         this.logIntakeUrl = logIntakeUrl;
+        this.inputTags = inputTags;
     }
 
     /**
@@ -99,6 +101,9 @@ public class DatadogHttpClient {
             points.add(point);
 
             JSONArray tags = new JSONArray();
+            for (String item:this.inputTags) {
+                tags.add(item);
+            }
             tags.addAll(Arrays.asList(datadogMetric.getTags()));
 
             JSONObject metric = new JSONObject();

--- a/src/test/java/org/datadog/jmeter/plugins/DatadogBackendClientTest.java
+++ b/src/test/java/org/datadog/jmeter/plugins/DatadogBackendClientTest.java
@@ -50,7 +50,7 @@ public class DatadogBackendClientTest
             put("sendResultsAsLogs", "true");
             put("includeSubresults", "false");
             put("samplersRegex", "^foo\\d*$");
-            put("inputTags","key:value");
+            put("customTags", "key:value");
         }
     };
     private ConcurrentAggregator aggregator = new ConcurrentAggregator();
@@ -94,7 +94,7 @@ public class DatadogBackendClientTest
         SampleResult result = createDummySampleResult("foo");
         this.client.handleSampleResults(Collections.singletonList(result), context);
         List<DatadogMetric> metrics = this.aggregator.flushMetrics();
-        String[] expectedTags = new String[] {"response_code:123", "sample_label:foo", "result:ok","key:value"};
+        String[] expectedTags = new String[] {"response_code:123", "sample_label:foo", "result:ok", "key:value"};
         String[] expectedMetricNames = new String[] {
                 "jmeter.responses_count",
                 "jmeter.latency.max",
@@ -186,7 +186,7 @@ public class DatadogBackendClientTest
         SampleResult resultA = createDummySampleResult("fooA");
 
         this.client.handleSampleResults(Arrays.asList(result1, resultA), context);
-        String[] expectedTagsResult1 = new String[] {"response_code:123", "sample_label:foo1", "result:ok"};
+        String[] expectedTagsResult1 = new String[] {"response_code:123", "sample_label:foo1", "result:ok", "key:value"};
         for(DatadogMetric metric : this.aggregator.flushMetrics()){
             Assert.assertArrayEquals(expectedTagsResult1, metric.getTags());
         }

--- a/src/test/java/org/datadog/jmeter/plugins/DatadogBackendClientTest.java
+++ b/src/test/java/org/datadog/jmeter/plugins/DatadogBackendClientTest.java
@@ -50,6 +50,7 @@ public class DatadogBackendClientTest
             put("sendResultsAsLogs", "true");
             put("includeSubresults", "false");
             put("samplersRegex", "^foo\\d*$");
+            put("inputTags","key:value");
         }
     };
     private ConcurrentAggregator aggregator = new ConcurrentAggregator();
@@ -93,7 +94,7 @@ public class DatadogBackendClientTest
         SampleResult result = createDummySampleResult("foo");
         this.client.handleSampleResults(Collections.singletonList(result), context);
         List<DatadogMetric> metrics = this.aggregator.flushMetrics();
-        String[] expectedTags = new String[] {"response_code:123", "sample_label:foo", "result:ok"};
+        String[] expectedTags = new String[] {"response_code:123", "sample_label:foo", "result:ok","key:value"};
         String[] expectedMetricNames = new String[] {
                 "jmeter.responses_count",
                 "jmeter.latency.max",

--- a/src/test/java/org/datadog/jmeter/plugins/DatadogBackendClientTest.java
+++ b/src/test/java/org/datadog/jmeter/plugins/DatadogBackendClientTest.java
@@ -95,79 +95,50 @@ public class DatadogBackendClientTest
         this.client.handleSampleResults(Collections.singletonList(result), context);
         List<DatadogMetric> metrics = this.aggregator.flushMetrics();
         String[] expectedTags = new String[] {"response_code:123", "sample_label:foo", "result:ok", "key:value"};
-        String[] expectedMetricNames = new String[] {
-                "jmeter.responses_count",
-                "jmeter.latency.max",
-                "jmeter.latency.min",
-                "jmeter.latency.p99",
-                "jmeter.latency.p95",
-                "jmeter.latency.p90",
-                "jmeter.latency.avg",
-                "jmeter.latency.count",
-                "jmeter.response_time.max",
-                "jmeter.response_time.min",
-                "jmeter.response_time.p99",
-                "jmeter.response_time.p95",
-                "jmeter.response_time.p90",
-                "jmeter.response_time.avg",
-                "jmeter.response_time.count",
-                "jmeter.bytes_received.max",
-                "jmeter.bytes_received.min",
-                "jmeter.bytes_received.p99",
-                "jmeter.bytes_received.p95",
-                "jmeter.bytes_received.p90",
-                "jmeter.bytes_received.avg",
-                "jmeter.bytes_received.count",
-                "jmeter.bytes_sent.max",
-                "jmeter.bytes_sent.min",
-                "jmeter.bytes_sent.p99",
-                "jmeter.bytes_sent.p95",
-                "jmeter.bytes_sent.p90",
-                "jmeter.bytes_sent.avg",
-                "jmeter.bytes_sent.count",
-        };
-        double[] expectedMetricValues = new double[] {
-                10.0,
-                0.01195256210245945,
-                0.01195256210245945,
-                0.01195256210245945,
-                0.01195256210245945,
-                0.01195256210245945,
-                0.012000000104308128,
-                1.0,
-                0.12624150202599055,
-                0.12624150202599055,
-                0.12624150202599055,
-                0.12624150202599055,
-                0.12624150202599055,
-                0.125,
-                1.0,
-                12291.916561360777,
-                12291.916561360777,
-                12291.916561360777,
-                12291.916561360777,
-                12291.916561360777,
-                12345.0,
-                1.0,
-                124.37724692430666,
-                124.37724692430666,
-                124.37724692430666,
-                124.37724692430666,
-                124.37724692430666,
-                124.0,
-                1.0,
+        Map<String, Double> expectedMetrics = new HashMap<String, Double>() {
+            {
+                put("jmeter.responses_count", 10.0);
+                put("jmeter.latency.max", 0.01195256210245945);
+                put("jmeter.latency.min", 0.01195256210245945);
+                put("jmeter.latency.p99", 0.01195256210245945);
+                put("jmeter.latency.p95", 0.01195256210245945);
+                put("jmeter.latency.p90", 0.01195256210245945);
+                put("jmeter.latency.avg", 0.012000000104308128);
+                put("jmeter.latency.count", 1.0);
+                put("jmeter.response_time.max", 0.12624150202599055);
+                put("jmeter.response_time.min", 0.12624150202599055);
+                put("jmeter.response_time.p99", 0.12624150202599055);
+                put("jmeter.response_time.p95", 0.12624150202599055);
+                put("jmeter.response_time.p90", 0.12624150202599055);
+                put("jmeter.response_time.avg", 0.125);
+                put("jmeter.response_time.count", 1.0);
+                put("jmeter.bytes_received.max", 12291.916561360777);
+                put("jmeter.bytes_received.min", 12291.916561360777);
+                put("jmeter.bytes_received.p99", 12291.916561360777);
+                put("jmeter.bytes_received.p95", 12291.916561360777);
+                put("jmeter.bytes_received.p90", 12291.916561360777);
+                put("jmeter.bytes_received.avg", 12345.0);
+                put("jmeter.bytes_received.count", 1.0);
+                put("jmeter.bytes_sent.max", 124.37724692430666);
+                put("jmeter.bytes_sent.min", 124.37724692430666);
+                put("jmeter.bytes_sent.p99", 124.37724692430666);
+                put("jmeter.bytes_sent.p95", 124.37724692430666);
+                put("jmeter.bytes_sent.p90", 124.37724692430666);
+                put("jmeter.bytes_sent.avg", 124.0);
+                put("jmeter.bytes_sent.count", 1.0);
+            }
         };
 
-        for(int i = 0; i < expectedMetricNames.length; i++){
-            DatadogMetric metric = metrics.get(i);
-            Assert.assertEquals(expectedMetricNames[i], metric.getName());
+        for(DatadogMetric metric : metrics) {
+            Assert.assertTrue(expectedMetrics.containsKey(metric.getName()));
+            Double expectedMetricValue = expectedMetrics.get(metric.getName());
             Assert.assertArrayEquals(expectedTags, metric.getTags());
             if(metric.getName().endsWith("count")) {
                 Assert.assertEquals("count", metric.getType());
             } else {
                 Assert.assertEquals("gauge", metric.getType());
             }
-            Assert.assertEquals(expectedMetricValues[i], metric.getValue(), 1e-12);
+            Assert.assertEquals(expectedMetricValue, metric.getValue(), 1e-12);
         }
     }
 

--- a/src/test/java/org/datadog/jmeter/plugins/DatadogConfigurationTest.java
+++ b/src/test/java/org/datadog/jmeter/plugins/DatadogConfigurationTest.java
@@ -5,6 +5,8 @@
 
 package org.datadog.jmeter.plugins;
 
+import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.PatternSyntaxException;
@@ -23,7 +25,7 @@ public class DatadogConfigurationTest {
     private static final String SEND_RESULTS_AS_LOGS = "sendResultsAsLogs";
     private static final String INCLUDE_SUB_RESULTS = "includeSubresults";
     private static final String SAMPLERS_REGEX = "samplersRegex";
-    private static final String INPUT_TAGS = "inputTags";
+    private static final String CUSTOM_TAGS = "customTags";
 
     @Test
     public void testArguments(){
@@ -39,7 +41,7 @@ public class DatadogConfigurationTest {
         Assert.assertTrue(argumentsMap.containsKey(SEND_RESULTS_AS_LOGS));
         Assert.assertTrue(argumentsMap.containsKey(INCLUDE_SUB_RESULTS));
         Assert.assertTrue(argumentsMap.containsKey(SAMPLERS_REGEX));
-        Assert.assertTrue(argumentsMap.containsKey(INPUT_TAGS));
+        Assert.assertTrue(argumentsMap.containsKey(CUSTOM_TAGS));
     }
 
     @Test
@@ -54,7 +56,7 @@ public class DatadogConfigurationTest {
                 put(SEND_RESULTS_AS_LOGS, "true");
                 put(INCLUDE_SUB_RESULTS, "false");
                 put(SAMPLERS_REGEX, "false");
-                put(INPUT_TAGS, "key:value");
+                put(CUSTOM_TAGS, "key:value");
             }
         };
 
@@ -66,7 +68,7 @@ public class DatadogConfigurationTest {
         Assert.assertEquals("logIntakeUrl", datadogConfiguration.getLogIntakeUrl());
         Assert.assertEquals(10, datadogConfiguration.getMetricsMaxBatchSize());
         Assert.assertEquals(11, datadogConfiguration.getLogsBatchSize());
-        Assert.assertEquals("key:value",datadogConfiguration.getInputTags());
+        Assert.assertEquals(new ArrayList<>(Arrays.asList("key:value")), datadogConfiguration.getCustomTags());
         Assert.assertTrue(datadogConfiguration.shouldSendResultsAsLogs());
         Assert.assertFalse(datadogConfiguration.shouldIncludeSubResults());
     }
@@ -154,33 +156,33 @@ public class DatadogConfigurationTest {
     }
 
     @Test
-    public void testNoValueProvidedForInputTags() throws DatadogConfigurationException {
+    public void testNoValueProvidedForCustomTags() throws DatadogConfigurationException {
         Map<String, String> config = new HashMap<String, String>() {
             {
                 put("apiKey", "123456");
-                put(INPUT_TAGS, "");
+                put(CUSTOM_TAGS, "");
             }
         };
         DatadogConfiguration.parseConfiguration(new BackendListenerContext(config));
     }
 
     @Test
-    public void testOnlyKeyForInputTags() throws DatadogConfigurationException {
+    public void testOnlyKeyForCustomTags() throws DatadogConfigurationException {
         Map<String, String> config = new HashMap<String, String>() {
             {
                 put("apiKey", "123456");
-                put(INPUT_TAGS, "key");
+                put(CUSTOM_TAGS, "key");
             }
         };
         DatadogConfiguration.parseConfiguration(new BackendListenerContext(config));
     }
 
     @Test
-    public void testSpecialCharacterForInputTags() throws DatadogConfigurationException {
+    public void testSpecialCharacterForCustomTags() throws DatadogConfigurationException {
         Map<String, String> config = new HashMap<String, String>() {
             {
                 put("apiKey", "123456");
-                put(INPUT_TAGS, "key*value");
+                put(CUSTOM_TAGS, "key*value");
             }
         };
         DatadogConfiguration.parseConfiguration(new BackendListenerContext(config));

--- a/src/test/java/org/datadog/jmeter/plugins/DatadogConfigurationTest.java
+++ b/src/test/java/org/datadog/jmeter/plugins/DatadogConfigurationTest.java
@@ -23,11 +23,12 @@ public class DatadogConfigurationTest {
     private static final String SEND_RESULTS_AS_LOGS = "sendResultsAsLogs";
     private static final String INCLUDE_SUB_RESULTS = "includeSubresults";
     private static final String SAMPLERS_REGEX = "samplersRegex";
+    private static final String INPUT_TAGS = "inputTags";
 
     @Test
     public void testArguments(){
         Arguments args = DatadogConfiguration.getPluginArguments();
-        Assert.assertEquals(8, args.getArgumentCount());
+        Assert.assertEquals(9, args.getArgumentCount());
 
         Map<String, String> argumentsMap = args.getArgumentsAsMap();
         Assert.assertTrue(argumentsMap.containsKey(API_URL_PARAM));
@@ -38,6 +39,7 @@ public class DatadogConfigurationTest {
         Assert.assertTrue(argumentsMap.containsKey(SEND_RESULTS_AS_LOGS));
         Assert.assertTrue(argumentsMap.containsKey(INCLUDE_SUB_RESULTS));
         Assert.assertTrue(argumentsMap.containsKey(SAMPLERS_REGEX));
+        Assert.assertTrue(argumentsMap.containsKey(INPUT_TAGS));
     }
 
     @Test
@@ -52,6 +54,7 @@ public class DatadogConfigurationTest {
                 put(SEND_RESULTS_AS_LOGS, "true");
                 put(INCLUDE_SUB_RESULTS, "false");
                 put(SAMPLERS_REGEX, "false");
+                put(INPUT_TAGS, "key:value");
             }
         };
 
@@ -63,6 +66,7 @@ public class DatadogConfigurationTest {
         Assert.assertEquals("logIntakeUrl", datadogConfiguration.getLogIntakeUrl());
         Assert.assertEquals(10, datadogConfiguration.getMetricsMaxBatchSize());
         Assert.assertEquals(11, datadogConfiguration.getLogsBatchSize());
+        Assert.assertEquals("key:value",datadogConfiguration.getInputTags());
         Assert.assertTrue(datadogConfiguration.shouldSendResultsAsLogs());
         Assert.assertFalse(datadogConfiguration.shouldIncludeSubResults());
     }
@@ -144,6 +148,39 @@ public class DatadogConfigurationTest {
             {
                 put("apiKey", "123456");
                 put(SAMPLERS_REGEX, "[asd]\\d+");
+            }
+        };
+        DatadogConfiguration.parseConfiguration(new BackendListenerContext(config));
+    }
+
+    @Test
+    public void testNoValueProvidedForInputTags() throws DatadogConfigurationException {
+        Map<String, String> config = new HashMap<String, String>() {
+            {
+                put("apiKey", "123456");
+                put(INPUT_TAGS, "");
+            }
+        };
+        DatadogConfiguration.parseConfiguration(new BackendListenerContext(config));
+    }
+
+    @Test
+    public void testOnlyKeyForInputTags() throws DatadogConfigurationException {
+        Map<String, String> config = new HashMap<String, String>() {
+            {
+                put("apiKey", "123456");
+                put(INPUT_TAGS, "key");
+            }
+        };
+        DatadogConfiguration.parseConfiguration(new BackendListenerContext(config));
+    }
+
+    @Test
+    public void testSpecialCharacterForInputTags() throws DatadogConfigurationException {
+        Map<String, String> config = new HashMap<String, String>() {
+            {
+                put("apiKey", "123456");
+                put(INPUT_TAGS, "key*value");
             }
         };
         DatadogConfiguration.parseConfiguration(new BackendListenerContext(config));


### PR DESCRIPTION
### Requirements for Contributing to this repository


### What does this PR do?



What inspired you to submit this pull request?
Need feature to send tag along with metrics sent to data dog. Currently this feature is absent.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
https://github.com/DataDog/jmeter-datadog-backend-listener/issues/14

### Description of the Change


Added in a new field in jmeter lister to provide tags. Tags can now be provided in format key:values with different items seperated by ","


### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
No other alternatives were considered

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
Performance implications as a result of these changes, possible test cases that I have not considered.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
Jmeter logging was enabled to see if new tags were added. Additionally verified in data dog if tags were present
- How did you verify that all changed functionality works as expected?
No verification done.
- How did you verify that the change has not introduced any regressions?
No verification done.
Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.
A load test was executed using Jmeter. Jmeter logging was enabled to see if new tags were added. Additionally verified in data dog if tags were present
-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

