### PR TITLE
fixed flaky test in DataDogBackendClientTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,12 @@
       <version>2.0.7</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -115,12 +115,6 @@
       <version>2.0.7</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.1</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/org/datadog/jmeter/plugins/DatadogBackendClientTest.java
+++ b/src/test/java/org/datadog/jmeter/plugins/DatadogBackendClientTest.java
@@ -27,6 +27,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import com.google.gson.JsonParser;
 
 /**
  * Unit test for simple App.
@@ -173,8 +174,9 @@ public class DatadogBackendClientTest
         SampleResult result = createDummySampleResult("foo");
         this.client.handleSampleResults(Collections.singletonList(result), context);
         Assert.assertEquals(1, this.logsBuffer.size());
+        JsonParser parser = new JsonParser();
         String expectedPayload = "{\"sample_start_time\":1.0,\"response_code\":\"123\",\"headers_size\":0.0,\"sample_label\":\"foo\",\"latency\":12.0,\"group_threads\":0.0,\"idle_time\":0.0,\"error_count\":0.0,\"message\":\"\",\"url\":\"\",\"ddsource\":\"jmeter\",\"sent_bytes\":124.0,\"thread_group\":\"bar\",\"body_size\":0.0,\"content_type\":\"\",\"load_time\":125.0,\"thread_name\":\"bar baz\",\"sample_end_time\":126.0,\"bytes\":12345.0,\"connect_time\":0.0,\"sample_count\":10.0,\"data_type\":\"\",\"all_threads\":0.0,\"data_encoding\":null}";
-        Assert.assertEquals(this.logsBuffer.get(0).toString(), expectedPayload);
+        Assert.assertEquals(parser.parse(this.logsBuffer.get(0).toString()), parser.parse(expectedPayload));
     }
 
     @Test

--- a/src/test/java/org/datadog/jmeter/plugins/DatadogBackendClientTest.java
+++ b/src/test/java/org/datadog/jmeter/plugins/DatadogBackendClientTest.java
@@ -13,7 +13,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.io.IOException;
 import net.minidev.json.JSONObject;
 import net.minidev.json.parser.JSONParser;
 import net.minidev.json.parser.ParseException;
@@ -172,18 +171,13 @@ public class DatadogBackendClientTest
     }
 
     @Test
-    public void testExtractLogs() throws IOException{
+    public void testExtractLogs() throws ParseException{
         SampleResult result = createDummySampleResult("foo");
         this.client.handleSampleResults(Collections.singletonList(result), context);
         Assert.assertEquals(1, this.logsBuffer.size());
         String expectedPayload = "{\"sample_start_time\":1.0,\"response_code\":\"123\",\"headers_size\":0.0,\"sample_label\":\"foo\",\"latency\":12.0,\"group_threads\":0.0,\"idle_time\":0.0,\"error_count\":0.0,\"message\":\"\",\"url\":\"\",\"ddsource\":\"jmeter\",\"sent_bytes\":124.0,\"thread_group\":\"bar\",\"body_size\":0.0,\"content_type\":\"\",\"load_time\":125.0,\"thread_name\":\"bar baz\",\"sample_end_time\":126.0,\"bytes\":12345.0,\"connect_time\":0.0,\"sample_count\":10.0,\"data_type\":\"\",\"all_threads\":0.0,\"data_encoding\":null}";
-        JSONParser parser = new JSONParser();
-        try {
-            Assert.assertEquals(parser.parse(this.logsBuffer.get(0).toString()), parser.parse(expectedPayload));
-        }
-        catch (ParseException ex) {
-            throw new IOException("Error while parsing payload from testExtractLogs ", ex);
-        }
+        JSONParser parser = new JSONParser(JSONParser.MODE_PERMISSIVE);
+        Assert.assertEquals(this.logsBuffer.get(0), parser.parse(expectedPayload));
     }
 
     @Test

--- a/src/test/java/org/datadog/jmeter/plugins/DatadogBackendClientTest.java
+++ b/src/test/java/org/datadog/jmeter/plugins/DatadogBackendClientTest.java
@@ -13,7 +13,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.io.IOException;
 import net.minidev.json.JSONObject;
+import net.minidev.json.parser.JSONParser;
+import net.minidev.json.parser.ParseException;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.visualizers.backend.BackendListenerContext;
 import org.datadog.jmeter.plugins.aggregation.ConcurrentAggregator;
@@ -27,7 +30,6 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import com.google.gson.JsonParser;
 
 /**
  * Unit test for simple App.
@@ -170,13 +172,18 @@ public class DatadogBackendClientTest
     }
 
     @Test
-    public void testExtractLogs() {
+    public void testExtractLogs() throws IOException{
         SampleResult result = createDummySampleResult("foo");
         this.client.handleSampleResults(Collections.singletonList(result), context);
         Assert.assertEquals(1, this.logsBuffer.size());
-        JsonParser parser = new JsonParser();
         String expectedPayload = "{\"sample_start_time\":1.0,\"response_code\":\"123\",\"headers_size\":0.0,\"sample_label\":\"foo\",\"latency\":12.0,\"group_threads\":0.0,\"idle_time\":0.0,\"error_count\":0.0,\"message\":\"\",\"url\":\"\",\"ddsource\":\"jmeter\",\"sent_bytes\":124.0,\"thread_group\":\"bar\",\"body_size\":0.0,\"content_type\":\"\",\"load_time\":125.0,\"thread_name\":\"bar baz\",\"sample_end_time\":126.0,\"bytes\":12345.0,\"connect_time\":0.0,\"sample_count\":10.0,\"data_type\":\"\",\"all_threads\":0.0,\"data_encoding\":null}";
-        Assert.assertEquals(parser.parse(this.logsBuffer.get(0).toString()), parser.parse(expectedPayload));
+        JSONParser parser = new JSONParser();
+        try {
+            Assert.assertEquals(parser.parse(this.logsBuffer.get(0).toString()), parser.parse(expectedPayload));
+        }
+        catch (ParseException ex) {
+            throw new IOException("Error while parsing payload from testExtractLogs ", ex);
+        }
     }
 
     @Test

--- a/src/test/java/org/datadog/jmeter/plugins/DatadogBackendClientTest.java
+++ b/src/test/java/org/datadog/jmeter/plugins/DatadogBackendClientTest.java
@@ -171,7 +171,7 @@ public class DatadogBackendClientTest
     }
 
     @Test
-    public void testExtractLogs() throws ParseException{
+    public void testExtractLogs() throws ParseException {
         SampleResult result = createDummySampleResult("foo");
         this.client.handleSampleResults(Collections.singletonList(result), context);
         Assert.assertEquals(1, this.logsBuffer.size());


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/README.md#contributing). 

### What does this PR do?

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->
The PR fixed the flaky test explained in [issue#32](https://github.com/DataDog/jmeter-datadog-backend-listener/issues/32).
### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
The cause of test failure is due to comparing two JSON strings. However the order of fields stored in `JSONObject` is non-deterministic. And you can get different results per run when you call the `toString()` method on a `JSONObject`. A simple fix is to use a `JSONParser` to parser the string back to `JSONObject`, and compare them instead.
### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
Almost none. It adds non-significant runtime for the test because of the `parse()`.
### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->
After the fix, use the reproduce procedure from [issue#32](https://github.com/DataDog/jmeter-datadog-backend-listener/issues/32), and the test will be passed.
### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

