### PR TITLE
Export GPG key to keyserver

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,7 @@ create_key:
   image: $REGISTRY/ci/agent-key-management-tools/gpg:1
   variables:
     PROJECT_NAME: "jmeter-datadog-backend-listener"
-    EXPORT_TO_KEYSERVER: "false"
+    EXPORT_TO_KEYSERVER: "true"
   script:
     - /create.sh
   artifacts:


### PR DESCRIPTION
### What does this PR do?
Enable exporting GPG key to keyserver. This is actually required since when releasing the JMeter plugin to Maven Central, it looks for the key:

```
[ERROR] Repository "comdatadoghq-1690" failures
[ERROR]   Rule "signature-staging" failures
[ERROR]     * No public key: Key with id: (913a2c9f1ca3f754) was not able to be located on &lt;a href=http://keyserver.ubuntu.com:11371/&gt;http://keyserver.ubuntu.com:11371/&lt;/a&gt;. Upload your public key and try the operation again.
[ERROR]     * No public key: Key with id: (913a2c9f1ca3f754) was not able to be located on &lt;a href=https://keys.openpgp.org/&gt;https://keys.openpgp.org/&lt;/a&gt;. Upload your public key and try the operation again.
...
```