### PR TITLE
Set configured tags on plugin generated logs

### DIFF
--- a/src/main/java/org/datadog/jmeter/plugins/DatadogBackendClient.java
+++ b/src/main/java/org/datadog/jmeter/plugins/DatadogBackendClient.java
@@ -143,7 +143,7 @@ public class DatadogBackendClient extends AbstractBackendListenerClient implemen
         this.sendMetrics();
 
         if (this.logsBuffer.size() > 0) {
-            this.datadogClient.submitLogs(this.logsBuffer);
+            this.datadogClient.submitLogs(this.logsBuffer, this.configuration.getCustomTags());
             this.logsBuffer.clear();
         }
         this.datadogClient = null;
@@ -177,7 +177,7 @@ public class DatadogBackendClient extends AbstractBackendListenerClient implemen
         if(configuration.shouldSendResultsAsLogs()) {
             this.extractLogs(sampleResult);
             if(logsBuffer.size() >= configuration.getLogsBatchSize()) {
-                datadogClient.submitLogs(logsBuffer);
+                datadogClient.submitLogs(logsBuffer, this.configuration.getCustomTags());
                 logsBuffer.clear();
             }
         }

--- a/src/main/java/org/datadog/jmeter/plugins/DatadogHttpClient.java
+++ b/src/main/java/org/datadog/jmeter/plugins/DatadogHttpClient.java
@@ -9,6 +9,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -16,6 +17,7 @@ import java.util.List;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import net.minidev.json.parser.JSONParser;
+import org.apache.http.client.utils.URIBuilder;
 import org.datadog.jmeter.plugins.metrics.DatadogMetric;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -156,13 +158,13 @@ public class DatadogHttpClient {
      *
      * @param payload the payload
      */
-    public void submitLogs(List<JSONObject> payload) {
+    public void submitLogs(List<JSONObject> payload, List<String> tags) {
         JSONArray logsArray = new JSONArray();
         logsArray.addAll(payload);
 
         HttpURLConnection conn;
         try {
-            URL url = new URL(this.logIntakeUrl);
+            URL url = new URL(buildLogsUrl(this.logIntakeUrl, tags));
             conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type", "application/json");
@@ -193,5 +195,14 @@ public class DatadogHttpClient {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    private String buildLogsUrl(String logsUrl, List<String> tags) throws URISyntaxException {
+        if (tags.isEmpty()) {
+            return logsUrl;
+        }
+        return new URIBuilder(logsUrl)
+            .addParameter("ddtags", String.join(",", tags))
+            .toString();
     }
 }


### PR DESCRIPTION
### What does this PR do?

This pull requests automatically set tags on logs sent by the JMeter plugin. This has been requested https://github.com/DataDog/jmeter-datadog-backend-listener/issues/40

### Description of the Change

Now, when the plugin is configured with custom tags and to generate log entries in DataDog, such log entries are tagged (as well as generated metrics) with provided tags. 

The change just passes configured tags as query parameter `ddtags` in `logsIntakeUrl` as an efficient way to set all the tags for a batch of log entries.

Modified existing `DatadogBackendClientTest` to also test that tags are correctly passed to `DatadogHttpClient`. Decided to modify existing test, as to keep test set short and follow same convention as other tests (with multiple assertions).

No specific automated test has been developed for checking new logic in `DatadogHttpClient`, since none existed. 

### Alternate Designs

An alternate could be setting the ddtags as part of each log entry, which would require only modifying `DatadogBackendClient`. But, this would be less network efficient as the tags would be duplicated for each log entry.

### Possible Drawbacks

Potential additional traffic, or storage required in DataDog due to the additional tags? Existing filters on JMeter logs not working because of new tags in logs?

### Verification Process

* Packaged the project (`mvn clean package`)
* copied the shaded jar to JMeter 5.5 `lib/ext` folder (replacing existing installation of the plugin)
* configure a test plan like the following one: 
  ```xml
    <jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
      <hashTree>
        <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
          <stringProp name="TestPlan.comments"></stringProp>
          <boolProp name="TestPlan.functional_mode">false</boolProp>
          <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
          <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
          <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
            <collectionProp name="Arguments.arguments"/>
          </elementProp>
          <stringProp name="TestPlan.user_define_classpath"></stringProp>
        </TestPlan>
        <hashTree>
          <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="true">
            <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
            <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
              <boolProp name="LoopController.continue_forever">false</boolProp>
              <stringProp name="LoopController.loops">1</stringProp>
            </elementProp>
            <stringProp name="ThreadGroup.num_threads">1</stringProp>
            <stringProp name="ThreadGroup.ramp_time">1</stringProp>
            <boolProp name="ThreadGroup.scheduler">false</boolProp>
            <stringProp name="ThreadGroup.duration"></stringProp>
            <stringProp name="ThreadGroup.delay"></stringProp>
            <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
          </ThreadGroup>
          <hashTree>
            <kg.apc.jmeter.samplers.DummySampler guiclass="kg.apc.jmeter.samplers.DummySamplerGui" testclass="kg.apc.jmeter.samplers.DummySampler" testname="jp@gc - Dummy Sampler" enabled="true">
              <boolProp name="WAITING">true</boolProp>
              <boolProp name="SUCCESFULL">true</boolProp>
              <stringProp name="RESPONSE_CODE">200</stringProp>
              <stringProp name="RESPONSE_MESSAGE">OK</stringProp>
              <stringProp name="REQUEST_DATA"></stringProp>
              <stringProp name="RESPONSE_DATA">OK</stringProp>
              <stringProp name="RESPONSE_TIME">${__Random(50,500)}</stringProp>
              <stringProp name="LATENCY">${__Random(1,50)}</stringProp>
              <stringProp name="CONNECT">${__Random(1,5)}</stringProp>
              <stringProp name="URL"></stringProp>
              <stringProp name="RESULT_CLASS">org.apache.jmeter.samplers.SampleResult</stringProp>
            </kg.apc.jmeter.samplers.DummySampler>
            <hashTree/>
            <BackendListener guiclass="BackendListenerGui" testclass="BackendListener" testname="Backend Listener" enabled="true">
              <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
                <collectionProp name="Arguments.arguments">
                  <elementProp name="apiKey" elementType="Argument">
                    <stringProp name="Argument.name">apiKey</stringProp>
                    <stringProp name="Argument.value">XXX</stringProp>
                    <stringProp name="Argument.metadata">=</stringProp>
                  </elementProp>
                  <elementProp name="datadogUrl" elementType="Argument">
                    <stringProp name="Argument.name">datadogUrl</stringProp>
                    <stringProp name="Argument.value">https://api.datadoghq.com/api/</stringProp>
                    <stringProp name="Argument.metadata">=</stringProp>
                  </elementProp>
                  <elementProp name="logIntakeUrl" elementType="Argument">
                    <stringProp name="Argument.name">logIntakeUrl</stringProp>
                    <stringProp name="Argument.value">https://http-intake.logs.datadoghq.com/v1/input/</stringProp>
                    <stringProp name="Argument.metadata">=</stringProp>
                  </elementProp>
                  <elementProp name="metricsMaxBatchSize" elementType="Argument">
                    <stringProp name="Argument.name">metricsMaxBatchSize</stringProp>
                    <stringProp name="Argument.value">200</stringProp>
                    <stringProp name="Argument.metadata">=</stringProp>
                  </elementProp>
                  <elementProp name="logsBatchSize" elementType="Argument">
                    <stringProp name="Argument.name">logsBatchSize</stringProp>
                    <stringProp name="Argument.value">500</stringProp>
                    <stringProp name="Argument.metadata">=</stringProp>
                  </elementProp>
                  <elementProp name="sendResultsAsLogs" elementType="Argument">
                    <stringProp name="Argument.name">sendResultsAsLogs</stringProp>
                    <stringProp name="Argument.value">true</stringProp>
                    <stringProp name="Argument.metadata">=</stringProp>
                  </elementProp>
                  <elementProp name="includeSubresults" elementType="Argument">
                    <stringProp name="Argument.name">includeSubresults</stringProp>
                    <stringProp name="Argument.value">false</stringProp>
                    <stringProp name="Argument.metadata">=</stringProp>
                  </elementProp>
                  <elementProp name="samplersRegex" elementType="Argument">
                    <stringProp name="Argument.name">samplersRegex</stringProp>
                    <stringProp name="Argument.value"></stringProp>
                    <stringProp name="Argument.metadata">=</stringProp>
                  </elementProp>
                  <elementProp name="customTags" elementType="Argument">
                    <stringProp name="Argument.name">customTags</stringProp>
                    <stringProp name="Argument.value">myTag:myTest</stringProp>
                    <stringProp name="Argument.metadata">=</stringProp>
                  </elementProp>
                </collectionProp>
              </elementProp>
              <stringProp name="classname">org.datadog.jmeter.plugins.DatadogBackendClient</stringProp>
            </BackendListener>
            <hashTree/>
          </hashTree>
        </hashTree>
      </hashTree>
    </jmeterTestPlan>
  ```
* Run test plan
* Verify in DataDog that configured tags are listed in log entries.
  <img width="1355" alt="image" src="https://github.com/DataDog/jmeter-datadog-backend-listener/assets/3179183/7a82a8ef-694d-420d-b1cd-8904f58a81c0">

### Additional Notes

None

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

