### PR TITLE
Fix java.lang.reflect.InaccessibleObjectException for Java 9 in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,18 @@
           <version>2.22.1</version>
           <configuration>
             <trimStackTrace>false</trimStackTrace>
+            <!--
+                Fixes java.lang.reflect.InaccessibleObjectException.
+                Reference: https://stackoverflow.com/questions/68113065/mockito-inaccessible-object-exception-while-creating-a-mock-object
+            -->
+            <argLine>
+              --add-opens java.base/java.lang=ALL-UNNAMED
+              --add-opens java.base/java.util=ALL-UNNAMED
+              --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+              --add-opens java.base/java.util.regex=ALL-UNNAMED
+              --add-opens java.base/java.util.function=ALL-UNNAMED
+              --add-opens java.base/java.util.stream=ALL-UNNAMED
+            </argLine>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Fixes java.lang.reflect.InaccessibleObjectException while running tests with Java 9+. The mock library requires access to non-public members of other modules, which might be blocked in Java 9. This can e overridden by command-line args.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

